### PR TITLE
Add tests for nested Hono apps

### DIFF
--- a/tests/hono/app.test.ts
+++ b/tests/hono/app.test.ts
@@ -214,19 +214,19 @@ describe("Middleware for Hono with nested app", () => {
   });
 
   it("Request counter", async () => {
-    const res = await app.request("/api/hello");
+    const res = await app.request("/api/v1/hello");
     expect(res.status).toBe(200);
 
     const requests = client.requestCounter.getAndResetRequests();
     expect(requests).toHaveLength(1);
-    expect(requests[0]).toMatchObject({ method: "GET", path: "/api/hello" });
+    expect(requests[0]).toMatchObject({ method: "GET", path: "/api/v1/hello" });
   });
 
   it("List endpoints", async () => {
     expect(client.startupData?.paths).toEqual([
       {
         method: "GET",
-        path: "/api/hello",
+        path: "/api/v1/hello",
       },
     ]);
   });

--- a/tests/hono/app.ts
+++ b/tests/hono/app.ts
@@ -58,7 +58,7 @@ export const getApp = async () => {
 };
 
 export const getNestedApp = async () => {
-  const app = new Hono();
+  const app = new Hono().basePath("/api");
   const nestedApp = new Hono();
 
   useApitally(app, {
@@ -69,7 +69,7 @@ export const getNestedApp = async () => {
   nestedApp.get("/hello", (c) => {
     return c.text("Hello");
   });
-  app.route("/api", nestedApp);
+  app.route("/v1", nestedApp);
 
   return app;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests for middleware behavior with a nested app, including request counting and endpoint listing for the `/api/v1/hello` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->