### PR TITLE
Add `setConsumer` helper functions

### DIFF
--- a/src/adonisjs/index.ts
+++ b/src/adonisjs/index.ts
@@ -3,12 +3,12 @@ import type { HttpContext } from "@adonisjs/core/http";
 import type { ApitallyConfig } from "../common/types.js";
 export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
 
-export const defineConfig = (config: ApitallyConfig) => {
+export function defineConfig(config: ApitallyConfig) {
   return config;
-};
+}
 
-export const captureError = (error: unknown, ctx: HttpContext) => {
+export function captureError(error: unknown, ctx: HttpContext) {
   if (error instanceof Error) {
     ctx.apitallyError = error;
   }
-};
+}

--- a/src/adonisjs/provider.ts
+++ b/src/adonisjs/provider.ts
@@ -41,7 +41,7 @@ export default class ApitallyProvider {
   }
 }
 
-const listRoutes = (router: Router) => {
+function listRoutes(router: Router) {
   const routes = router.toJSON();
   const paths: Array<PathInfo> = [];
   for (const domain in routes) {
@@ -57,9 +57,9 @@ const listRoutes = (router: Router) => {
     }
   }
   return paths;
-};
+}
 
-const getVersions = (appVersion?: string) => {
+function getVersions(appVersion?: string) {
   const versions = [["nodejs", process.version.replace(/^v/, "")]];
   const adonisJsVersion = getPackageVersion("@adonisjs/core");
   const apitallyVersion = getPackageVersion("../..");
@@ -73,4 +73,4 @@ const getVersions = (appVersion?: string) => {
     versions.push(["app", appVersion]);
   }
   return Object.fromEntries(versions);
-};
+}

--- a/src/express/index.ts
+++ b/src/express/index.ts
@@ -1,2 +1,2 @@
-export type { ApitallyConsumer } from "../common/types.js";
-export { useApitally } from "./middleware.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
+export { setConsumer, useApitally } from "./middleware.js";

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -26,10 +26,10 @@ declare module "express" {
   }
 }
 
-export const useApitally = (
+export function useApitally(
   app: Express | Router,
   config: ApitallyConfig & { basePath?: string },
-) => {
+) {
   const client = new ApitallyClient(config);
   const middleware = getMiddleware(app, client);
   app.use(middleware);
@@ -43,9 +43,9 @@ export const useApitally = (
     }
   };
   setTimeout(() => setStartupData(), 500);
-};
+}
 
-const getMiddleware = (app: Express | Router, client: ApitallyClient) => {
+function getMiddleware(app: Express | Router, client: ApitallyClient) {
   let errorHandlerConfigured = false;
 
   return (req: Request, res: Response, next: NextFunction) => {
@@ -185,9 +185,9 @@ const getMiddleware = (app: Express | Router, client: ApitallyClient) => {
       next();
     }
   };
-};
+}
 
-const getRoutePath = (req: Request) => {
+function getRoutePath(req: Request) {
   if (!req.route) {
     return;
   }
@@ -199,9 +199,9 @@ const getRoutePath = (req: Request) => {
     }
   }
   return req.route.path;
-};
+}
 
-const getRouterPath = (stack: any[], baseUrl: string) => {
+function getRouterPath(stack: any[], baseUrl: string) {
   const routerPaths: string[] = [];
   while (stack && stack.length > 0) {
     const routerLayer = stack.find(
@@ -240,9 +240,16 @@ const getRouterPath = (stack: any[], baseUrl: string) => {
     }
   }
   return routerPaths.filter((path) => path !== "/").join("");
-};
+}
 
-const getConsumer = (req: Request) => {
+export function setConsumer(
+  req: Request,
+  consumer: ApitallyConsumer | string | null | undefined,
+) {
+  req.apitallyConsumer = consumer || undefined;
+}
+
+function getConsumer(req: Request) {
   if (req.apitallyConsumer) {
     return consumerFromStringOrObject(req.apitallyConsumer);
   } else if (req.consumerIdentifier) {
@@ -254,9 +261,9 @@ const getConsumer = (req: Request) => {
     return consumerFromStringOrObject(req.consumerIdentifier);
   }
   return null;
-};
+}
 
-const extractExpressValidatorErrors = (responseBody: any) => {
+function extractExpressValidatorErrors(responseBody: any) {
   try {
     const errors: ValidationError[] = [];
     if (
@@ -278,9 +285,9 @@ const extractExpressValidatorErrors = (responseBody: any) => {
   } catch (error) {
     return [];
   }
-};
+}
 
-const extractCelebrateErrors = (responseBody: any) => {
+function extractCelebrateErrors(responseBody: any) {
   try {
     const errors: ValidationError[] = [];
     if (responseBody && responseBody.validation) {
@@ -305,9 +312,9 @@ const extractCelebrateErrors = (responseBody: any) => {
   } catch (error) {
     return [];
   }
-};
+}
 
-const extractNestValidationErrors = (responseBody: any) => {
+function extractNestValidationErrors(responseBody: any) {
   try {
     const errors: ValidationError[] = [];
     if (responseBody && Array.isArray(responseBody.message)) {
@@ -323,20 +330,20 @@ const extractNestValidationErrors = (responseBody: any) => {
   } catch (error) {
     return [];
   }
-};
+}
 
-const subsetJoiMessage = (message: string, key: string) => {
+function subsetJoiMessage(message: string, key: string) {
   const messageWithKey = message
     .split(". ")
     .find((message) => message.includes(`"${key}"`));
   return messageWithKey ? messageWithKey : message;
-};
+}
 
-const getAppInfo = (
+function getAppInfo(
   app: Express | Router,
   basePath?: string,
   appVersion?: string,
-): StartupData => {
+): StartupData {
   const versions: Array<[string, string]> = [
     ["nodejs", process.version.replace(/^v/, "")],
   ];
@@ -360,4 +367,4 @@ const getAppInfo = (
     versions: Object.fromEntries(versions),
     client: "js:express",
   };
-};
+}

--- a/src/fastify/index.ts
+++ b/src/fastify/index.ts
@@ -1,2 +1,2 @@
-export type { ApitallyConsumer } from "../common/types.js";
-export { default as apitallyPlugin } from "./plugin.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
+export { default as apitallyPlugin, setConsumer } from "./plugin.js";

--- a/src/fastify/plugin.ts
+++ b/src/fastify/plugin.ts
@@ -164,7 +164,7 @@ const apitallyPlugin: FastifyPluginAsync<ApitallyConfig> = async (
   });
 };
 
-const getAppInfo = (routes: PathInfo[], appVersion?: string) => {
+function getAppInfo(routes: PathInfo[], appVersion?: string) {
   const versions = [["nodejs", process.version.replace(/^v/, "")]];
   const fastifyVersion = getPackageVersion("fastify");
   const apitallyVersion = getPackageVersion("../..");
@@ -182,9 +182,16 @@ const getAppInfo = (routes: PathInfo[], appVersion?: string) => {
     versions: Object.fromEntries(versions),
     client: "js:fastify",
   };
-};
+}
 
-const getConsumer = (request: FastifyRequest) => {
+export function setConsumer(
+  request: FastifyRequest,
+  consumer: ApitallyConsumer | string | null | undefined,
+) {
+  request.apitallyConsumer = consumer || undefined;
+}
+
+function getConsumer(request: FastifyRequest) {
   if (request.apitallyConsumer) {
     return consumerFromStringOrObject(request.apitallyConsumer);
   } else if (request.consumerIdentifier) {
@@ -196,18 +203,18 @@ const getConsumer = (request: FastifyRequest) => {
     return consumerFromStringOrObject(request.consumerIdentifier);
   }
   return null;
-};
+}
 
-const getResponseTime = (reply: FastifyReply) => {
+function getResponseTime(reply: FastifyReply) {
   if (reply.elapsedTime !== undefined) {
     return reply.elapsedTime;
   } else if ((reply as any).getResponseTime !== undefined) {
     return (reply as any).getResponseTime();
   }
   return 0;
-};
+}
 
-const extractAjvErrors = (message: string): ValidationError[] => {
+function extractAjvErrors(message: string): ValidationError[] {
   const regex =
     /(?<=^|, )((?:headers|params|query|querystring|body)[/.][^ ]+)(?= )/g;
   const matches: { match: string; index: number }[] = [];
@@ -229,7 +236,7 @@ const extractAjvErrors = (message: string): ValidationError[] => {
       type: "",
     };
   });
-};
+}
 
 export default fp(apitallyPlugin, {
   name: "apitally",

--- a/src/h3/index.ts
+++ b/src/h3/index.ts
@@ -1,2 +1,2 @@
-export type { ApitallyConsumer } from "../common/types.js";
-export { apitallyPlugin } from "./plugin.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
+export { apitallyPlugin, setConsumer } from "./plugin.js";

--- a/src/h3/plugin.ts
+++ b/src/h3/plugin.ts
@@ -131,9 +131,9 @@ export const apitallyPlugin = definePlugin<ApitallyConfig>((app, config) => {
         {
           statusCode,
           responseTime: responseTime / 1000,
-          headers: responseHeaders
-            ? convertHeaders(Object.fromEntries(responseHeaders.entries()))
-            : [],
+          headers: convertHeaders(
+            Object.fromEntries(responseHeaders.entries()),
+          ),
           size: responseSize,
           body: responseBody,
         },
@@ -178,6 +178,13 @@ export const apitallyPlugin = definePlugin<ApitallyConfig>((app, config) => {
       }),
     );
 });
+
+export function setConsumer(
+  event: H3Event,
+  consumer: ApitallyConsumer | string | null | undefined,
+) {
+  event.context.apitallyConsumer = consumer || undefined;
+}
 
 function getConsumer(event: H3Event) {
   const consumer = event.context.apitallyConsumer;

--- a/src/hono/index.ts
+++ b/src/hono/index.ts
@@ -1,2 +1,2 @@
-export type { ApitallyConsumer } from "../common/types.js";
-export { useApitally } from "./middleware.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
+export { setConsumer, useApitally } from "./middleware.js";

--- a/src/hono/middleware.ts
+++ b/src/hono/middleware.ts
@@ -137,7 +137,14 @@ function getMiddleware(client: ApitallyClient): MiddlewareHandler {
   };
 }
 
-export function getConsumer(c: Context) {
+export function setConsumer(
+  c: Context,
+  consumer: ApitallyConsumer | string | null | undefined,
+) {
+  c.set("apitallyConsumer", consumer || undefined);
+}
+
+function getConsumer(c: Context) {
   const consumer = c.get("apitallyConsumer");
   if (consumer) {
     return consumerFromStringOrObject(consumer);

--- a/src/koa/index.ts
+++ b/src/koa/index.ts
@@ -1,2 +1,2 @@
-export type { ApitallyConsumer } from "../common/types.js";
-export { useApitally } from "./middleware.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
+export { setConsumer, useApitally } from "./middleware.js";

--- a/src/nestjs/index.ts
+++ b/src/nestjs/index.ts
@@ -4,14 +4,14 @@ import { Response } from "express";
 
 import type { ApitallyConfig } from "../common/types.js";
 import { useApitally as useApitallyExpress } from "../express/index.js";
-export type { ApitallyConsumer } from "../common/types.js";
+export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
 
-export const useApitally = (app: INestApplication, config: ApitallyConfig) => {
+export function useApitally(app: INestApplication, config: ApitallyConfig) {
   const httpAdapter = app.getHttpAdapter();
   const expressInstance = httpAdapter.getInstance();
   useApitallyExpress(expressInstance, config);
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
-};
+}
 
 @Catch()
 class AllExceptionsFilter extends BaseExceptionFilter {

--- a/tests/express/app.ts
+++ b/tests/express/app.ts
@@ -3,7 +3,7 @@ import type { Request } from "express";
 import express from "express";
 import { body, query, validationResult } from "express-validator";
 
-import { useApitally } from "../../src/express/index.js";
+import { setConsumer, useApitally } from "../../src/express/index.js";
 import { CLIENT_ID, ENV } from "../utils.js";
 
 const requestLoggingConfig = {
@@ -37,7 +37,7 @@ export const getAppWithCelebrate = () => {
       { abortEarly: false },
     ),
     (req: Request, res) => {
-      req.apitallyConsumer = "test";
+      setConsumer(req, "test");
       res.type("txt");
       res.send(
         `Hello ${req.query?.name}! You are ${req.query?.age} years old!`,
@@ -87,7 +87,7 @@ export const getAppWithValidator = () => {
     query("name").isString().isLength({ min: 2 }),
     query("age").isInt({ min: 18 }),
     (req: Request, res) => {
-      req.apitallyConsumer = "test";
+      setConsumer(req, "test");
       const result = validationResult(req);
       if (result.isEmpty()) {
         res.type("txt");

--- a/tests/fastify/app.ts
+++ b/tests/fastify/app.ts
@@ -1,6 +1,6 @@
 import Fastify from "fastify";
 
-import { apitallyPlugin } from "../../src/fastify/index.js";
+import { apitallyPlugin, setConsumer } from "../../src/fastify/index.js";
 import { CLIENT_ID, ENV } from "../utils.js";
 
 export const getApp = async () => {
@@ -47,7 +47,7 @@ export const getApp = async () => {
     },
     async function (request) {
       const { name, age } = request.query;
-      request.apitallyConsumer = "test";
+      setConsumer(request, "test");
       return `Hello ${name}! You are ${age} years old!`;
     },
   );

--- a/tests/h3/app.ts
+++ b/tests/h3/app.ts
@@ -7,7 +7,7 @@ import {
 } from "h3";
 import { z } from "zod";
 
-import { apitallyPlugin } from "../../src/h3/index.js";
+import { apitallyPlugin, setConsumer } from "../../src/h3/index.js";
 import { CLIENT_ID, ENV } from "../utils.js";
 
 export const getApp = async () => {
@@ -44,7 +44,7 @@ export const getApp = async () => {
     "/hello",
     defineEventHandler(async (event) => {
       const { name, age } = await getValidatedQuery(event, querySchema.parse);
-      event.context.apitallyConsumer = "test";
+      setConsumer(event, "test");
       return `Hello ${name}! You are ${age} years old!`;
     }),
   );

--- a/tests/hono/app.ts
+++ b/tests/hono/app.ts
@@ -2,7 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
-import { useApitally } from "../../src/hono/index.js";
+import { setConsumer, useApitally } from "../../src/hono/index.js";
 import { CLIENT_ID, ENV } from "../utils.js";
 
 export const getApp = async () => {
@@ -32,7 +32,7 @@ export const getApp = async () => {
       }),
     ),
     (c) => {
-      c.set("apitallyConsumer", "test");
+      setConsumer(c, "test");
       return c.text(
         `Hello ${c.req.query("name")}! You are ${c.req.query("age")} years old!`,
       );

--- a/tests/koa/app.ts
+++ b/tests/koa/app.ts
@@ -3,7 +3,7 @@ import Koa from "koa";
 import bodyParser from "koa-bodyparser";
 import route from "koa-route";
 
-import { useApitally } from "../../src/koa/index.js";
+import { setConsumer, useApitally } from "../../src/koa/index.js";
 import { CLIENT_ID, ENV } from "../utils.js";
 
 const requestLoggingConfig = {
@@ -27,7 +27,7 @@ export const getAppWithKoaRouter = () => {
   });
 
   router.get("/hello", async (ctx) => {
-    ctx.state.apitallyConsumer = "test";
+    setConsumer(ctx, "test");
     ctx.body = `Hello ${ctx.query.name}! You are ${ctx.query.age} years old!`;
   });
   router.get("/hello/:id", async (ctx) => {
@@ -61,7 +61,7 @@ export const getAppWithKoaRoute = () => {
   app.use(bodyParser());
   app.use(
     route.get("/hello", async (ctx) => {
-      ctx.state.apitallyConsumer = "test";
+      setConsumer(ctx, "test");
       ctx.body = `Hello ${ctx.query.name}! You are ${ctx.query.age} years old!`;
     }),
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new utility function to set the consumer context for Express, Fastify, H3, Hono, and Koa integrations.

- **Refactor**
  - Improved function declaration style across multiple integrations for better clarity and consistency.
  - Updated internal logic to use the new consumer-setting utility, replacing direct property assignments.

- **Tests**
  - Updated test applications to use the new consumer-setting function for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->