### PR TITLE
Rename `requestLoggingConfig` to `requestLogging` in config

### DIFF
--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -54,6 +54,7 @@ export class ApitallyClient {
   constructor({
     clientId,
     env = "dev",
+    requestLogging,
     requestLoggingConfig,
     logger,
   }: ApitallyConfig) {
@@ -70,6 +71,11 @@ export class ApitallyClient {
         `Invalid env '${env}' (expecting 1-32 alphanumeric lowercase characters and hyphens only)`,
       );
     }
+    if (requestLoggingConfig && !requestLogging) {
+      console.warn(
+        "requestLoggingConfig is deprecated, use requestLogging instead.",
+      );
+    }
 
     ApitallyClient.instance = this;
     this.clientId = clientId;
@@ -77,11 +83,13 @@ export class ApitallyClient {
     this.instanceUuid = randomUUID();
     this.syncDataQueue = [];
     this.requestCounter = new RequestCounter();
-    this.requestLogger = new RequestLogger(requestLoggingConfig);
+    this.requestLogger = new RequestLogger(
+      requestLogging ?? requestLoggingConfig,
+    );
     this.validationErrorCounter = new ValidationErrorCounter();
     this.serverErrorCounter = new ServerErrorCounter();
     this.consumerRegistry = new ConsumerRegistry();
-    this.logger = logger || getLogger();
+    this.logger = logger ?? getLogger();
 
     this.startSync();
     this.handleShutdown = this.handleShutdown.bind(this);

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -4,9 +4,12 @@ import { RequestLoggingConfig } from "./requestLogger.js";
 export type ApitallyConfig = {
   clientId: string;
   env?: string;
-  requestLoggingConfig?: Partial<RequestLoggingConfig>;
+  requestLogging?: Partial<RequestLoggingConfig>;
   appVersion?: string;
   logger?: Logger;
+
+  /** @deprecated Use requestLogging instead */
+  requestLoggingConfig?: Partial<RequestLoggingConfig>;
 };
 
 export type ApitallyConsumer = {

--- a/tests/adonisjs/app.ts
+++ b/tests/adonisjs/app.ts
@@ -23,7 +23,7 @@ export const createApp = async () => {
       clientId: CLIENT_ID,
       env: ENV,
       appVersion: "1.2.3",
-      requestLoggingConfig: {
+      requestLogging: {
         enabled: true,
         logQueryParams: true,
         logRequestHeaders: true,

--- a/tests/express/app.ts
+++ b/tests/express/app.ts
@@ -22,7 +22,7 @@ export const getAppWithCelebrate = () => {
   useApitally(app, {
     clientId: CLIENT_ID,
     env: ENV,
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   app.get(
@@ -79,7 +79,7 @@ export const getAppWithValidator = () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   app.get(
@@ -134,7 +134,7 @@ export const getAppWithMiddlewareOnRouter = () => {
     env: ENV,
     appVersion: "1.2.3",
     basePath: "/api",
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   router.get("/hello", (req, res) => {
@@ -156,7 +156,7 @@ export const getAppWithNestedRouters = () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   router1.get("/health", (req, res) => {

--- a/tests/fastify/app.ts
+++ b/tests/fastify/app.ts
@@ -12,7 +12,7 @@ export const getApp = async () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig: {
+    requestLogging: {
       enabled: true,
       logQueryParams: true,
       logRequestHeaders: true,

--- a/tests/h3/app.ts
+++ b/tests/h3/app.ts
@@ -18,7 +18,7 @@ export const getApp = async () => {
         clientId: CLIENT_ID,
         env: ENV,
         appVersion: "1.2.3",
-        requestLoggingConfig: {
+        requestLogging: {
           enabled: true,
           logQueryParams: true,
           logRequestHeaders: true,

--- a/tests/hono/app.ts
+++ b/tests/hono/app.ts
@@ -12,7 +12,7 @@ export const getApp = async () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig: {
+    requestLogging: {
       enabled: true,
       logQueryParams: true,
       logRequestHeaders: true,

--- a/tests/koa/app.ts
+++ b/tests/koa/app.ts
@@ -23,7 +23,7 @@ export const getAppWithKoaRouter = () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   router.get("/hello", async (ctx) => {
@@ -55,7 +55,7 @@ export const getAppWithKoaRoute = () => {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig,
+    requestLogging: requestLoggingConfig,
   });
 
   app.use(bodyParser());

--- a/tests/nestjs/app.ts
+++ b/tests/nestjs/app.ts
@@ -15,7 +15,7 @@ export async function getApp() {
     clientId: CLIENT_ID,
     env: ENV,
     appVersion: "1.2.3",
-    requestLoggingConfig: {
+    requestLogging: {
       enabled: true,
       logQueryParams: true,
       logRequestHeaders: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option for request logging, replacing the previous option while maintaining backward compatibility.

* **Refactor**
  * Updated configuration property names for request logging across all supported frameworks to use the new naming convention.
  * Deprecated the old request logging configuration property in favor of the new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->