### PR TITLE
Always exclude OPTIONS requests

### DIFF
--- a/src/adonisjs/middleware.ts
+++ b/src/adonisjs/middleware.ts
@@ -21,7 +21,10 @@ export default class ApitallyMiddleware {
     const client: ApitallyClient =
       await ctx.containerResolver.make("apitallyClient");
 
-    if (!client.isEnabled()) {
+    if (
+      !client.isEnabled() ||
+      ctx.request.method().toUpperCase() === "OPTIONS"
+    ) {
       await next();
       return;
     }

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -49,7 +49,7 @@ function getMiddleware(app: Express | Router, client: ApitallyClient) {
   let errorHandlerConfigured = false;
 
   return (req: Request, res: Response, next: NextFunction) => {
-    if (!client.isEnabled()) {
+    if (!client.isEnabled() || req.method.toUpperCase() === "OPTIONS") {
       next();
       return;
     }

--- a/src/h3/plugin.ts
+++ b/src/h3/plugin.ts
@@ -42,6 +42,10 @@ export const apitallyPlugin = definePlugin<ApitallyConfig>((app, config) => {
     response?: Response,
     error?: HTTPError,
   ) => {
+    if (event.req.method.toUpperCase() === "OPTIONS") {
+      return response;
+    }
+
     const startTime = event.context._apitallyRequestTimestamp;
     const responseTime = startTime ? performance.now() - startTime : 0;
     const path = event.context.matchedRoute?.route;

--- a/src/h3/utils.ts
+++ b/src/h3/utils.ts
@@ -30,7 +30,12 @@ export function getAppInfo(h3: H3, appVersion?: string) {
         method: route.method || "",
         path: route.route || "",
       }))
-      .filter((route) => route.method && route.path),
+      .filter(
+        (route) =>
+          route.method &&
+          route.path &&
+          !["HEAD", "OPTIONS"].includes(route.method.toUpperCase()),
+      ),
     versions: Object.fromEntries(versions),
     client: "js:h3",
   };

--- a/src/hono/middleware.ts
+++ b/src/hono/middleware.ts
@@ -38,7 +38,7 @@ export function useApitally(app: Hono, config: ApitallyConfig) {
 
 function getMiddleware(client: ApitallyClient): MiddlewareHandler {
   return async (c, next) => {
-    if (!client.isEnabled()) {
+    if (!client.isEnabled() || c.req.method.toUpperCase() === "OPTIONS") {
       await next();
       return;
     }

--- a/src/hono/utils.ts
+++ b/src/hono/utils.ts
@@ -34,7 +34,10 @@ export function getAppInfo(app: Hono, appVersion?: string): StartupData {
 export function listEndpoints(app: Hono) {
   const endpoints: Array<PathInfo> = [];
   app.routes.forEach((route) => {
-    if (route.method !== "ALL" && !isMiddleware(route.handler)) {
+    if (
+      !["ALL", "HEAD", "OPTIONS"].includes(route.method.toUpperCase()) &&
+      !isMiddleware(route.handler)
+    ) {
       endpoints.push({
         method: route.method.toUpperCase(),
         path: route.path,

--- a/src/koa/middleware.ts
+++ b/src/koa/middleware.ts
@@ -29,10 +29,11 @@ export function useApitally(app: Koa, config: ApitallyConfig) {
 
 function getMiddleware(client: ApitallyClient) {
   return async (ctx: Koa.Context, next: Koa.Next) => {
-    if (!client.isEnabled()) {
+    if (!client.isEnabled() || ctx.request.method.toUpperCase() === "OPTIONS") {
       await next();
       return;
     }
+
     let path: string | undefined;
     let statusCode: number | undefined;
     let serverError: Error | undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Middleware now correctly bypasses processing for HTTP OPTIONS requests across multiple frameworks, preventing unnecessary handling or logging for these requests.
  * Route and endpoint listings now exclude OPTIONS and HEAD methods, providing a more accurate and relevant set of available endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->