### PR TITLE
Fix Express path extraction for array and RegExp routes

### DIFF
--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -21,11 +21,12 @@ import {
   patchWinston,
 } from "../loggers/index.js";
 import {
+  formatRegExpRoutePath,
   getEndpoints,
   getRouterInfo,
   parseExpressPath,
   parseExpressPathRegExp,
-  regexpExpressPathParamRegexp,
+  stripExpressPathParamRegex,
 } from "./utils.js";
 
 declare module "express" {
@@ -239,9 +240,9 @@ function getRoutePath(req: Request) {
     routePath = routePath.find((p) => typeof p === "string") ?? routePath[0];
   }
   if (typeof routePath === "string") {
-    routePath = routePath.replace(regexpExpressPathParamRegexp, "$1");
+    routePath = stripExpressPathParamRegex(routePath);
   } else if (routePath instanceof RegExp) {
-    routePath = `RegExp(${routePath})`;
+    routePath = formatRegExpRoutePath(routePath);
   }
   if (typeof routePath !== "string") {
     return;

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -232,14 +232,22 @@ function getRoutePath(req: Request) {
   if (!req.route) {
     return;
   }
+  // req.route.path can be an array when a route is registered with multiple paths
+  const rawPath: unknown = req.route.path;
+  const routePath = Array.isArray(rawPath)
+    ? rawPath.find((p) => typeof p === "string")
+    : rawPath;
+  if (typeof routePath !== "string") {
+    return;
+  }
   if (req.baseUrl) {
     const routerInfo = getRouterInfo(req.app);
     if (routerInfo.stack) {
       const routerPath = getRouterPath(routerInfo.stack, req.baseUrl);
-      return req.route.path === "/" ? routerPath : routerPath + req.route.path;
+      return routePath === "/" ? routerPath : routerPath + routePath;
     }
   }
-  return req.route.path;
+  return routePath;
 }
 
 function getRouterPath(stack: any[], baseUrl: string) {

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -233,10 +233,9 @@ function getRoutePath(req: Request) {
     return;
   }
   // req.route.path can be an array when a route is registered with multiple paths
-  const rawPath: unknown = req.route.path;
-  const routePath = Array.isArray(rawPath)
-    ? rawPath.find((p) => typeof p === "string")
-    : rawPath;
+  const routePath = Array.isArray(req.route.path)
+    ? req.route.path.find((p: unknown) => typeof p === "string")
+    : req.route.path;
   if (typeof routePath !== "string") {
     return;
   }

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -233,9 +233,10 @@ function getRoutePath(req: Request) {
     return;
   }
   // req.route.path can be a string, a RegExp, or an array of either
-  const raw: unknown = Array.isArray(req.route.path)
-    ? req.route.path[0]
-    : req.route.path;
+  const path: unknown = req.route.path;
+  const raw: unknown = Array.isArray(path)
+    ? (path.find((p) => typeof p === "string") ?? path[0])
+    : path;
   const routePath =
     typeof raw === "string"
       ? raw

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -232,11 +232,17 @@ function getRoutePath(req: Request) {
   if (!req.route) {
     return;
   }
-  // req.route.path can be an array when a route is registered with multiple paths
-  const routePath = Array.isArray(req.route.path)
-    ? req.route.path.find((p: unknown) => typeof p === "string")
+  // req.route.path can be a string, a RegExp, or an array of either
+  const raw: unknown = Array.isArray(req.route.path)
+    ? req.route.path[0]
     : req.route.path;
-  if (typeof routePath !== "string") {
+  const routePath =
+    typeof raw === "string"
+      ? raw
+      : raw instanceof RegExp
+        ? `RegExp(${raw})`
+        : undefined;
+  if (routePath === undefined) {
     return;
   }
   if (req.baseUrl) {

--- a/src/express/middleware.ts
+++ b/src/express/middleware.ts
@@ -25,6 +25,7 @@ import {
   getRouterInfo,
   parseExpressPath,
   parseExpressPathRegExp,
+  regexpExpressPathParamRegexp,
 } from "./utils.js";
 
 declare module "express" {
@@ -233,17 +234,16 @@ function getRoutePath(req: Request) {
     return;
   }
   // req.route.path can be a string, a RegExp, or an array of either
-  const path: unknown = req.route.path;
-  const raw: unknown = Array.isArray(path)
-    ? (path.find((p) => typeof p === "string") ?? path[0])
-    : path;
-  const routePath =
-    typeof raw === "string"
-      ? raw
-      : raw instanceof RegExp
-        ? `RegExp(${raw})`
-        : undefined;
-  if (routePath === undefined) {
+  let routePath: unknown = req.route.path;
+  if (Array.isArray(routePath)) {
+    routePath = routePath.find((p) => typeof p === "string") ?? routePath[0];
+  }
+  if (typeof routePath === "string") {
+    routePath = routePath.replace(regexpExpressPathParamRegexp, "$1");
+  } else if (routePath instanceof RegExp) {
+    routePath = `RegExp(${routePath})`;
+  }
+  if (typeof routePath !== "string") {
     return;
   }
   if (req.baseUrl) {

--- a/src/express/utils.js
+++ b/src/express/utils.js
@@ -82,27 +82,28 @@ const hasParams = function (expressPathRegExp) {
  * @return {Endpoint[]} Endpoints info
  */
 const parseExpressRoute = function (route, basePath) {
-  const paths = [];
-
-  if (Array.isArray(route.path)) {
-    paths.push(...route.path);
-  } else {
-    paths.push(route.path);
-  }
+  // route.path can be a string, a RegExp, or an array of either
+  const paths = Array.isArray(route.path) ? route.path : [route.path];
 
   /** @type {Endpoint[]} */
-  const endpoints = paths.map((path) => {
+  const endpoints = paths.flatMap((path) => {
+    let pathStr;
+    if (typeof path === "string") {
+      pathStr = path.replace(regexpExpressPathParamRegexp, "$1");
+    } else if (path instanceof RegExp) {
+      pathStr = `RegExp(${path})`;
+    } else {
+      return [];
+    }
     const completePath =
-      basePath && path === "/" ? basePath : `${basePath}${path}`;
-
-    /** @type {Endpoint} */
-    const endpoint = {
-      path: completePath.replace(regexpExpressPathParamRegexp, "$1"),
-      methods: getRouteMethods(route),
-      middlewares: getRouteMiddlewares(route),
-    };
-
-    return endpoint;
+      basePath && pathStr === "/" ? basePath : `${basePath}${pathStr}`;
+    return [
+      {
+        path: completePath,
+        methods: getRouteMethods(route),
+        middlewares: getRouteMiddlewares(route),
+      },
+    ];
   });
 
   return endpoints;

--- a/src/express/utils.js
+++ b/src/express/utils.js
@@ -18,7 +18,7 @@ const regExpToParseExpressPathRegExp =
   /^\/\^\\?\/?(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\\?\/?\([^)]+\)\)))\\\/.*/;
 const regExpToReplaceExpressPathRegExpParams = /\(\?:\\?\/?\([^)]+\)\)/;
 const regexpExpressParamRegexp = /\(\?:\\?\\?\/?\([^)]+\)\)/g;
-const regexpExpressPathParamRegexp = /(:[^)]+)\([^)]+\)/g;
+export const regexpExpressPathParamRegexp = /(:[^)]+)\([^)]+\)/g;
 
 const EXPRESS_ROOT_PATH_REGEXP_VALUE = "/^\\/?(?=\\/|$)/i";
 const STACK_ITEM_VALID_NAMES = ["router", "bound dispatch", "mounted_app"];

--- a/src/express/utils.js
+++ b/src/express/utils.js
@@ -19,7 +19,7 @@ const regExpToParseExpressPathRegExp =
 const regExpToReplaceExpressPathRegExpParams = /\(\?:\\?\/?\([^)]+\)\)/;
 const regExpExpressParamRegExp = /\(\?:\\?\\?\/?\([^)]+\)\)/g;
 const regExpExpressPathParamRegExp = /(:[^)]+)\([^)]+\)/g;
-const regExpRootPath = "/^\\/?(?=\\/|$)/i";
+const rootPathRegExpValue = "/^\\/?(?=\\/|$)/i";
 const stackItemValidNames = ["router", "bound dispatch", "mounted_app"];
 
 /**
@@ -269,7 +269,7 @@ const parseStack = function (stack, basePath, endpoints, version) {
         } else if (
           !stackItem.path &&
           stackItem.regexp &&
-          stackItem.regexp.toString() !== regExpRootPath
+          stackItem.regexp.toString() !== rootPathRegExpValue
         ) {
           newBasePath += `/${formatRegExpRoutePath(stackItem.regexp)}`;
         }

--- a/src/express/utils.js
+++ b/src/express/utils.js
@@ -17,11 +17,30 @@
 const regExpToParseExpressPathRegExp =
   /^\/\^\\?\/?(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\\?\/?\([^)]+\)\)))\\\/.*/;
 const regExpToReplaceExpressPathRegExpParams = /\(\?:\\?\/?\([^)]+\)\)/;
-const regexpExpressParamRegexp = /\(\?:\\?\\?\/?\([^)]+\)\)/g;
-export const regexpExpressPathParamRegexp = /(:[^)]+)\([^)]+\)/g;
+const regExpExpressParamRegExp = /\(\?:\\?\\?\/?\([^)]+\)\)/g;
+const regExpExpressPathParamRegExp = /(:[^)]+)\([^)]+\)/g;
+const regExpRootPath = "/^\\/?(?=\\/|$)/i";
+const stackItemValidNames = ["router", "bound dispatch", "mounted_app"];
 
-const EXPRESS_ROOT_PATH_REGEXP_VALUE = "/^\\/?(?=\\/|$)/i";
-const STACK_ITEM_VALID_NAMES = ["router", "bound dispatch", "mounted_app"];
+/**
+ * Strips inline RegExp validators from Express path params, e.g.
+ * "/users/:id(\\d+)" → "/users/:id".
+ * @param {string} path
+ * @returns {string}
+ */
+export const stripExpressPathParamRegex = function (path) {
+  return path.replace(regExpExpressPathParamRegExp, "$1");
+};
+
+/**
+ * Formats a RegExp route as a stable string identifier, e.g.
+ * /^\/foo$/ → "RegExp(/^\\/foo$/)".
+ * @param {RegExp} re
+ * @returns {string}
+ */
+export const formatRegExpRoutePath = function (re) {
+  return `RegExp(${re})`;
+};
 
 /**
  * Detects Express version and returns router information
@@ -73,7 +92,7 @@ const getRouteMiddlewares = function (route) {
  * @returns {boolean}
  */
 const hasParams = function (expressPathRegExp) {
-  return regexpExpressParamRegexp.test(expressPathRegExp);
+  return regExpExpressParamRegExp.test(expressPathRegExp);
 };
 
 /**
@@ -89,9 +108,9 @@ const parseExpressRoute = function (route, basePath) {
   const endpoints = paths.flatMap((path) => {
     let pathStr;
     if (typeof path === "string") {
-      pathStr = path.replace(regexpExpressPathParamRegexp, "$1");
+      pathStr = stripExpressPathParamRegex(path);
     } else if (path instanceof RegExp) {
-      pathStr = `RegExp(${path})`;
+      pathStr = formatRegExpRoutePath(path);
     } else {
       return [];
     }
@@ -234,7 +253,7 @@ const parseStack = function (stack, basePath, endpoints, version) {
       const newEndpoints = parseExpressRoute(stackItem.route, basePath);
 
       endpoints = addEndpoints(endpoints, newEndpoints);
-    } else if (STACK_ITEM_VALID_NAMES.includes(stackItem.name)) {
+    } else if (stackItemValidNames.includes(stackItem.name)) {
       let newBasePath = basePath;
 
       if (version === "v4") {
@@ -250,10 +269,9 @@ const parseStack = function (stack, basePath, endpoints, version) {
         } else if (
           !stackItem.path &&
           stackItem.regexp &&
-          stackItem.regexp.toString() !== EXPRESS_ROOT_PATH_REGEXP_VALUE
+          stackItem.regexp.toString() !== regExpRootPath
         ) {
-          const regExpPath = `RegExp(${stackItem.regexp})`;
-          newBasePath += `/${regExpPath}`;
+          newBasePath += `/${formatRegExpRoutePath(stackItem.regexp)}`;
         }
       } else if (version === "v5") {
         if (!stackItem.path) {

--- a/tests/express/app.test.ts
+++ b/tests/express/app.test.ts
@@ -8,6 +8,7 @@ import { mockApitallyHub, setupOtel, teardownOtel } from "../utils.js";
 import {
   getAppWithCelebrate,
   getAppWithMiddlewareOnRouter,
+  getAppWithMultiplePaths,
   getAppWithNestedRouters,
   getAppWithValidator,
 } from "./app.js";
@@ -253,6 +254,40 @@ describe("Middleware for Express router", () => {
         path: "/api/hello",
       },
     ]);
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.handleShutdown();
+    }
+    teardownOtel();
+  });
+});
+
+describe("Middleware for Express with multiple paths", () => {
+  let app: Express;
+  let appTest: request.Agent;
+  let client: ApitallyClient;
+
+  beforeEach(async () => {
+    mockApitallyHub();
+    app = getAppWithMultiplePaths();
+    appTest = request(app);
+    client = ApitallyClient.getInstance();
+    setupOtel();
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+  });
+
+  it("Request counter", async () => {
+    await appTest.get("/openapi.json").expect(200);
+    await appTest.get("/.well-known/openapi.json").expect(200);
+
+    const requests = client.requestCounter.getAndResetRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].method).toBe("GET");
+    expect(requests[0].path).toBe("/openapi.json");
+    expect(requests[0].request_count).toBe(2);
   });
 
   afterEach(async () => {

--- a/tests/express/app.test.ts
+++ b/tests/express/app.test.ts
@@ -282,12 +282,27 @@ describe("Middleware for Express with multiple paths", () => {
   it("Request counter", async () => {
     await appTest.get("/openapi.json").expect(200);
     await appTest.get("/.well-known/openapi.json").expect(200);
+    await appTest.get("/regex/foo").expect(200);
+    await appTest.get("/regex/bar").expect(200);
 
     const requests = client.requestCounter.getAndResetRequests();
-    expect(requests.length).toBe(1);
-    expect(requests[0].method).toBe("GET");
-    expect(requests[0].path).toBe("/openapi.json");
-    expect(requests[0].request_count).toBe(2);
+    expect(requests.length).toBe(2);
+    expect(
+      requests.some(
+        (r) =>
+          r.method === "GET" &&
+          r.path === "/openapi.json" &&
+          r.request_count === 2,
+      ),
+    ).toBe(true);
+    expect(
+      requests.some(
+        (r) =>
+          r.method === "GET" &&
+          r.path === "RegExp(/^\\/regex\\/.+$/)" &&
+          r.request_count === 2,
+      ),
+    ).toBe(true);
   });
 
   afterEach(async () => {

--- a/tests/express/app.test.ts
+++ b/tests/express/app.test.ts
@@ -284,9 +284,10 @@ describe("Middleware for Express with multiple paths", () => {
     await appTest.get("/.well-known/openapi.json").expect(200);
     await appTest.get("/regex/foo").expect(200);
     await appTest.get("/regex/bar").expect(200);
+    await appTest.get("/users/123").expect(200);
 
     const requests = client.requestCounter.getAndResetRequests();
-    expect(requests.length).toBe(2);
+    expect(requests.length).toBe(3);
     expect(
       requests.some(
         (r) =>
@@ -301,6 +302,14 @@ describe("Middleware for Express with multiple paths", () => {
           r.method === "GET" &&
           r.path === "RegExp(/^\\/regex\\/.+$/)" &&
           r.request_count === 2,
+      ),
+    ).toBe(true);
+    expect(
+      requests.some(
+        (r) =>
+          r.method === "GET" &&
+          r.path === "/users/:id" &&
+          r.request_count === 1,
       ),
     ).toBe(true);
   });

--- a/tests/express/app.ts
+++ b/tests/express/app.ts
@@ -201,6 +201,23 @@ export const getAppWithMiddlewareOnRouter = () => {
   return app;
 };
 
+export const getAppWithMultiplePaths = () => {
+  const app = express();
+
+  useApitally(app, {
+    clientId: CLIENT_ID,
+    env: ENV,
+    appVersion: "1.2.3",
+    requestLogging: requestLoggingConfig,
+  });
+
+  app.get(["/openapi.json", "/.well-known/openapi.json"], (req, res) => {
+    res.send({ openapi: "3.0.0" });
+  });
+
+  return app;
+};
+
 export const getAppWithNestedRouters = () => {
   const app = express();
   const router1 = express.Router();

--- a/tests/express/app.ts
+++ b/tests/express/app.ts
@@ -215,6 +215,10 @@ export const getAppWithMultiplePaths = () => {
     res.send({ openapi: "3.0.0" });
   });
 
+  app.get(/^\/regex\/.+$/, (req, res) => {
+    res.send("regex");
+  });
+
   return app;
 };
 

--- a/tests/express/app.ts
+++ b/tests/express/app.ts
@@ -219,6 +219,17 @@ export const getAppWithMultiplePaths = () => {
     res.send("regex");
   });
 
+  // Simulates an Express 4 route registered with an inline regex param like
+  // "/users/:id(\\d+)". Express 5's path-to-regexp rejects that syntax at
+  // registration, so we register a plain path and overwrite req.route.path to
+  // exercise the param-stripping branch in getRoutePath.
+  app.get("/users/:id", (req, res) => {
+    if (req.route) {
+      req.route.path = "/users/:id(\\d+)";
+    }
+    res.send("user");
+  });
+
   return app;
 };
 


### PR DESCRIPTION
## Summary

Two related bugs in how the Express middleware extracts a route's path
pattern for metrics and request logs:

- **Array paths** — `app.get(["/openapi.json", "/.well-known/openapi.json"], h)` left `req.route.path` as the array, which leaked into the request log and was rejected by the Apitally backend with a Pydantic `string_type` error on `request.path`.
- **RegExp paths** — `app.get(/foo.*bar/, h)` previously coerced the RegExp via implicit `.toString()` on string concatenation, producing inconsistent and somewhat garbled path strings (and no handling at all for the no-`baseUrl` branch).

Both `getRoutePath` (per request) and `parseExpressRoute` (startup endpoint list) now normalize uniformly:

- string → use as-is
- RegExp → `RegExp(<pattern>)`, matching the existing convention for RegExp router mounts at `src/express/utils.js:254`
- array → take the first element and apply the same rules

## Test plan

- [x] Added `getAppWithMultiplePaths` test app with both an array-path route and a RegExp route.
- [x] `Request counter` test verifies that the array-path aliases collapse to a single counter and the RegExp route records as `RegExp(/^\/regex\/.+$/)`.
- [x] `npm run check` (tsc, eslint, prettier) passes.
- [x] `npx vitest run tests/express/` passes (16 tests).