### PR TITLE
Fix internal CommonJS default imports

### DIFF
--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -1,22 +1,22 @@
 import fetchRetry from "fetch-retry";
 import { randomUUID } from "node:crypto";
 
-import ConsumerRegistry from "./consumerRegistry.js";
+import { ConsumerRegistry } from "./consumerRegistry.js";
 import { getOrCreateInstanceUuid } from "./instance.js";
 import { Logger, getLogger } from "./logging.js";
 import { isValidClientId, isValidEnv } from "./paramValidation.js";
-import RequestCounter from "./requestCounter.js";
-import RequestLogger from "./requestLogger.js";
+import { RequestCounter } from "./requestCounter.js";
+import { RequestLogger } from "./requestLogger.js";
 import { getCpuMemoryUsage } from "./resources.js";
-import ServerErrorCounter from "./serverErrorCounter.js";
-import SpanCollector from "./spanCollector.js";
+import { ServerErrorCounter } from "./serverErrorCounter.js";
+import { SpanCollector } from "./spanCollector.js";
 import {
   ApitallyConfig,
   StartupData,
   StartupPayload,
   SyncPayload,
 } from "./types.js";
-import ValidationErrorCounter from "./validationErrorCounter.js";
+import { ValidationErrorCounter } from "./validationErrorCounter.js";
 
 const SYNC_INTERVAL = 60000; // 60 seconds
 const INITIAL_SYNC_INTERVAL = 10000; // 10 seconds

--- a/src/common/consumerRegistry.ts
+++ b/src/common/consumerRegistry.ts
@@ -55,3 +55,5 @@ export default class ConsumerRegistry {
     return data;
   }
 }
+
+export { ConsumerRegistry };

--- a/src/common/requestCounter.ts
+++ b/src/common/requestCounter.ts
@@ -115,3 +115,5 @@ export default class RequestCounter {
     return data;
   }
 }
+
+export { RequestCounter };

--- a/src/common/requestLogger.ts
+++ b/src/common/requestLogger.ts
@@ -9,7 +9,7 @@ import {
   truncateExceptionStackTrace,
 } from "./serverErrorCounter.js";
 import type { SpanData } from "./spanCollector.js";
-import TempGzipFile, { checkWritableFs } from "./tempGzipFile.js";
+import { checkWritableFs, TempGzipFile } from "./tempGzipFile.js";
 
 const MAX_BODY_SIZE = 50_000; // 50 KB (uncompressed)
 const MAX_FILE_SIZE = 1_000_000; // 1 MB (compressed)
@@ -660,3 +660,5 @@ function truncateLogMessage(msg: string) {
   }
   return msg;
 }
+
+export { RequestLogger };

--- a/src/common/serverErrorCounter.ts
+++ b/src/common/serverErrorCounter.ts
@@ -94,3 +94,5 @@ export function truncateExceptionStackTrace(stack: string) {
   }
   return truncatedLines.join("\n");
 }
+
+export { ServerErrorCounter };

--- a/src/common/spanCollector.ts
+++ b/src/common/spanCollector.ts
@@ -222,3 +222,5 @@ export class ApitallySpanProcessor implements SpanProcessor {
     this.getCollector()?.forceFlush();
   }
 }
+
+export { SpanCollector };

--- a/src/common/tempGzipFile.ts
+++ b/src/common/tempGzipFile.ts
@@ -102,3 +102,5 @@ export default class TempGzipFile {
     await unlink(this.filePath);
   }
 }
+
+export { TempGzipFile };

--- a/src/common/validationErrorCounter.ts
+++ b/src/common/validationErrorCounter.ts
@@ -58,3 +58,5 @@ export default class ValidationErrorCounter {
     return createHash("md5").update(hashInput).digest("hex");
   }
 }
+
+export { ValidationErrorCounter };

--- a/src/elysia/index.ts
+++ b/src/elysia/index.ts
@@ -1,2 +1,2 @@
 export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
-export { default as apitallyPlugin } from "./plugin.js";
+export { apitallyPlugin } from "./plugin.js";

--- a/src/elysia/plugin.ts
+++ b/src/elysia/plugin.ts
@@ -344,3 +344,5 @@ function getStatusCode(set: Context["set"]) {
     return StatusMap[set.status];
   }
 }
+
+export { apitallyPlugin };

--- a/src/fastify/index.ts
+++ b/src/fastify/index.ts
@@ -1,2 +1,5 @@
 export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
-export { default as apitallyPlugin, setConsumer } from "./plugin.js";
+export {
+  apitallyFastifyPlugin as apitallyPlugin,
+  setConsumer,
+} from "./plugin.js";

--- a/src/fastify/plugin.ts
+++ b/src/fastify/plugin.ts
@@ -341,6 +341,8 @@ function extractNestValidationErrors(message: any[]): ValidationError[] {
 
 export { apitallyPlugin };
 
-export default fp(apitallyPlugin, {
+export const apitallyFastifyPlugin = fp(apitallyPlugin, {
   name: "apitally",
 });
+
+export default apitallyFastifyPlugin;

--- a/src/hapi/index.ts
+++ b/src/hapi/index.ts
@@ -1,2 +1,2 @@
 export type { ApitallyConfig, ApitallyConsumer } from "../common/types.js";
-export { default as apitallyPlugin, setConsumer } from "./plugin.js";
+export { apitallyPlugin, setConsumer } from "./plugin.js";

--- a/src/hapi/plugin.ts
+++ b/src/hapi/plugin.ts
@@ -296,3 +296,5 @@ export function setConsumer(
 ) {
   request.apitallyConsumer = consumer || undefined;
 }
+
+export { apitallyPlugin };


### PR DESCRIPTION
## Summary

- preserve unbundled CJS and ESM output
- use named exports for internal modules while retaining existing default exports
- avoid esbuild Node-mode default interop for generated internal CJS imports

Fixes #285

## Validation

- `npm run check`
- `npm test -- --run` (115 passed, 1 skipped)
- `npm run build`
- `npx attw --pack .`
- packed CommonJS POC on Node 22.14: `CJS_BOOT_OK`
- packed ESM POC on Node 22.14: `ESM_BOOT_OK`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes internal CommonJS imports so the package now loads correctly in Node.js CommonJS environments, resolving issue #285. Previously, generated CJS output failed to resolve default imports of internal modules; now internal modules use named exports and imports while retaining existing default exports for public API compatibility.

- Adds named exports to internal common modules and Elysia, Fastify, and Hapi plugins.
- Fastify plugin now also exports an aliased `apitallyFastifyPlugin` constant alongside the default export.
- Public consumer-facing exports (`apitallyPlugin`, `setConsumer`) behave as before.

<sup>Written for commit 3e12a9f19d070128cb100c142e07fea47a74b131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-js/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

